### PR TITLE
Add Elasticsearch option to maintain logs and change ELBs to ALBs

### DIFF
--- a/integrator/integrator-ha.yaml
+++ b/integrator/integrator-ha.yaml
@@ -529,6 +529,11 @@ Resources:
                 - !Ref ProductVersion
             - !Join
               - ''
+              - - sed -i "s/Product_Version/
+                - !Ref ProductVersion
+                - /g" /etc/filebeat/filebeat.yml
+            - !Join
+              - ''
               - - sed -i "s^ELASTICSEARCH_ENDPOINT^
                 - !Ref ElasticSearchEndpoint
                 - ^g" /etc/filebeat/filebeat.yml
@@ -649,6 +654,11 @@ Resources:
               - ''
               - - export ProductVersion=
                 - !Ref ProductVersion
+            - !Join
+              - ''
+              - - sed -i "s/Product_Version/
+                - !Ref ProductVersion
+                - /g" /etc/filebeat/filebeat.yml
             - !Join
               - ''
               - - sed -i "s^ELASTICSEARCH_ENDPOINT^
@@ -1000,14 +1010,14 @@ Mappings:
       Ubuntu1804: ami-009d089713dae1887
   WSO2EIAMIRegionMap:
     ap-southeast-2:
-      Ubuntu1804: ami-022549174964e916b
+      Ubuntu1804: ami-0a017892a7b655b0c
     eu-west-1:
-      Ubuntu1804: ami-0961894e19ce08142
+      Ubuntu1804: ami-041cdd4bb10bf55a9
     us-east-1:
-      Ubuntu1804: ami-0ccb4945e74d10fc5
+      Ubuntu1804: ami-0a000eeff453a3c0e
     us-east-2:
-      Ubuntu1804: ami-04b9a444e56fed93d
+      Ubuntu1804: ami-0a2ed85fc335a1ca0
     us-west-1:
-      Ubuntu1804: ami-06c2c5a11123363ed
+      Ubuntu1804: ami-0b8d72e3b63b802f9
     us-west-2:
-      Ubuntu1804: ami-0b6a55159dbc3b079
+      Ubuntu1804: ami-06623e0f8da384975

--- a/integrator/integrator-ha.yaml
+++ b/integrator/integrator-ha.yaml
@@ -592,7 +592,6 @@ Resources:
                   /g"
                   /usr/lib/wso2/wso2ei/${ProductVersion}/wso2ei-${ProductVersion}/conf/axis2/axis2.xml
             - /usr/lib/wso2/wso2ei/${ProductVersion}/wso2ei-${ProductVersion}/bin/integrator.sh start
-            - mkdir /usr/lib/wso2/wso2ei/${ProductVersion}/wso2ei-${ProductVersion}/mydir
             - ${CustomUserData}
             - echo 'export HISTTIMEFORMAT="%F %T "' >> /etc/profile.d/history.sh
             - cat /dev/null > ~/.bash_history && history -c
@@ -684,7 +683,7 @@ Resources:
             - service puppet restart
             - mkdir -p /mnt/efs
             - !Sub "mount -t nfs4 -o nfsvers=4.1 ${WSO2EIEFSFileSystem}.efs.${AWS::Region}.amazonaws.com:/ /mnt/efs"
-            - sleep 200
+            - sleep 300
             - export FACTER_profile=ei_integrator${ProductVersion//.}
             - puppet agent -vt
             - 'if [ ! -d "/mnt/efs/deployment/server" ]; then'

--- a/integrator/integrator-ha.yaml
+++ b/integrator/integrator-ha.yaml
@@ -26,7 +26,6 @@ Metadata:
           - KeyPairName
           - WSO2InstanceType
           - OperatingSystem
-          - ProductVersion
       - Label:
           default: Network Configuration
         Parameters:
@@ -84,8 +83,6 @@ Metadata:
         default: DB Engine
       OperatingSystem:
         default: OS Version
-      ProductVersion:
-        default: EI Version
 Resources:
   # networking configurations
   WSO2EIVPC:
@@ -861,13 +858,6 @@ Parameters:
   LogArchiveS3Bucket:
     Type: String
     Default: ""
-  ProductVersion:
-    Type: String
-    Default: 6.4.0
-    AllowedValues:
-      - 6.4.0
-      - 6.1.1
-      - 6.1.0
 Mappings:
   WSO2PuppetMasterRegionMap:
     ap-southeast-2:

--- a/integrator/integrator-ha.yaml
+++ b/integrator/integrator-ha.yaml
@@ -987,17 +987,17 @@ Parameters:
 Mappings:
   WSO2PuppetMasterRegionMap:
     ap-southeast-2:
-      Ubuntu1804: ami-02148022ba42bf57c
+      Ubuntu1804: ami-04736a51961858ebf
     eu-west-1:
-      Ubuntu1804: ami-0eb6f72263e3a7343
+      Ubuntu1804: ami-0e83183b95e190afc
     us-east-1:
-      Ubuntu1804: ami-07d85d28eed1ecb20
+      Ubuntu1804: ami-0782bf8d5455e6ad0
     us-east-2:
-      Ubuntu1804: ami-0b3e8926de60d5a28
+      Ubuntu1804: ami-001ca894bac471a1b
     us-west-1:
-      Ubuntu1804: ami-0be3d1c2a20f79668
+      Ubuntu1804: ami-0089a017e2b6851a7
     us-west-2:
-      Ubuntu1804: ami-0c14a1a779549fba7
+      Ubuntu1804: ami-009d089713dae1887
   WSO2EIAMIRegionMap:
     ap-southeast-2:
       Ubuntu1804: ami-022549174964e916b

--- a/integrator/integrator-ha.yaml
+++ b/integrator/integrator-ha.yaml
@@ -14,7 +14,7 @@
 
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  WSO2 Enterprise Integrator Clustered deployment with Analytics Configured
+  WSO2 Enterprise Integrator Clustered deployment
 Metadata:
   'AWS::CloudFormation::Interface':
     ParameterGroups:

--- a/integrator/integrator-ha.yaml
+++ b/integrator/integrator-ha.yaml
@@ -362,126 +362,38 @@ Resources:
           GroupSet:
             - !Ref PuppetMasterSecurityGroup
       UserData: !Base64
-        'Fn::Join':
-          - |+
-
-          - - '#!/bin/bash'
-            - 'export PATH=~/.local/bin:$PATH'
-            - echo "> Set hostname to puppetmaster"
-            - hostname puppetmaster
-            - echo $(hostname) >> /etc/hostname
-            - echo "127.0.0.1 $(hostname)" >> /etc/hosts
-            - sed -i '/\[main\]/a dns_alt_names=puppetmaster,puppet' /etc/puppet/puppet.conf
-            - sed -i '/\[master\]/a autosign=true' /etc/puppet/puppet.conf
-            - !Join
-              - ''
-              - - export ProductVersion=
-                - !Ref ProductVersion
-            - service puppetmaster restart
-            - !Sub "./home/ubuntu/wso2-init.sh ${WUMUsername} ${WUMPassword} wso2ei-${ProductVersion} ${InternalPrepareForTest}"
-            - !Join
-              - ''
-              - - sed -i "s/access-key/
-                - !Ref AWSAccessKeyId
-                - /g" /etc/puppet/code/environments/production/modules/ei_integrator${ProductVersion//.}/manifests/params.pp
-            - !Join
-              - ''
-              - - sed -i "s/REGION_NAME/
-                - !Ref "AWS::Region"
-                - /g" /etc/puppet/code/environments/production/modules/ei_integrator${ProductVersion//.}/manifests/params.pp
-            - !Join
-              - ''
-              - - sed -i "s/CF_ELB_DNS_NAME/
-                - !GetAtt
-                  - WSO2EILoadBalancer
-                  - DNSName
-                - >-
-                  /g"
-                  /etc/puppet/code/environments/production/modules/ei_integrator${ProductVersion//.}/manifests/params.pp
-            - !Join
-              - ''
-              - - sed -i "s/CF_DB_USERNAME/
-                - !Ref DBUsername
-                - /g" /etc/puppet/code/environments/production/modules/ei_integrator${ProductVersion//.}/manifests/params.pp
-            - !Join
-              - ''
-              - - sed -i "s/CF_DB_PASSWORD/
-                - !Ref DBPassword
-                - /g" /etc/puppet/code/environments/production/modules/ei_integrator${ProductVersion//.}/manifests/params.pp
-            - !Join
-              - ''
-              - - sed -i "s/CF_RDS_URL/
-                - !GetAtt
-                  - WSO2EIDBInstance
-                  - Endpoint.Address
-                - /g" /etc/puppet/code/environments/production/modules/ei_integrator${ProductVersion//.}/manifests/params.pp
-            - !Join
-              - ''
-              - - sed -i "s/BROKER_ELB_DNS_NAME/
-                - 'localhost'
-                - >-
-                  /g"
-                  /etc/puppet/code/environments/production/modules/ei_integrator${ProductVersion//.}/manifests/params.pp
-            - !Join
-              - ''
-              - - sed -i "s^secretkey^
-                - !Ref AWSAccessKeySecret
-                - ^g" /etc/puppet/code/environments/production/modules/ei_integrator${ProductVersion//.}/manifests/params.pp
-            - !Join
-              - ''
-              - - sed -i "s/JDK_TYPE/
-                - !Ref JDK
-                - /g" /etc/puppet/code/environments/production/modules/ei_integrator${ProductVersion//.}/manifests/params.pp
-            - !Join
-              - ''
-              - - export DB_HOSTNAME=
-                - !GetAtt
-                  - WSO2EIDBInstance
-                  - Endpoint.Address
-            - !Join
-              - ''
-              - - export DB_PORT=
-                - !GetAtt
-                  - WSO2EIDBInstance
-                  - Endpoint.Port
-            - !Join
-              - ''
-              - - export DB_USERNAME=
-                - !Ref DBUsername
-            - !Join
-              - ''
-              - - export DB_PASSWORD=
-                - !Ref DBPassword
-            - !Join
-             - ''
-             - - sed -i "s/JDK_TYPE/
-               - !Ref JDK
-               - /g" /etc/puppet/code/environments/production/modules/ei_integrator${ProductVersion//.}/manifests/params.pp
-            - !Join
-              - ''
-              - - sed -i "s/CF_DB_USERNAME/
-                - !Ref DBUsername
-                - /g" /usr/local/bin/provision_db_ei.sh
-            - !Join
-              - ''
-              - - sed -i "s/CF_DB_PASSWORD/
-                - !Ref DBPassword
-                - /g" /usr/local/bin/provision_db_ei.sh
-            - !Join
-              - ''
-              - - sed -i "s/CF_DB_HOST/
-                - !GetAtt
-                  - WSO2EIDBInstance
-                  - Endpoint.Address
-                - /g" /usr/local/bin/provision_db_ei.sh
-            - !Join
-              - ''
-              - - sed -i "s/CF_DB_PORT/
-                - !GetAtt
-                  - WSO2EIDBInstance
-                  - Endpoint.Port
-                - /g" /usr/local/bin/provision_db_ei.sh
-            - bash /usr/local/bin/provision_db_ei.sh
+        'Fn::Sub': |
+          #cloud-boothook
+          #!/bin/bash
+          export PATH=~/.local/bin:$PATH
+          echo "> Set hostname to puppetmaster"
+          hostname puppetmaster
+          echo $(hostname) >> /etc/hostname
+          echo "127.0.0.1 $(hostname)" >> /etc/hosts
+          sed -i '/\[main\]/a dns_alt_names=puppetmaster,puppet' /etc/puppet/puppet.conf
+          sed -i '/\[master\]/a autosign=true' /etc/puppet/puppet.conf
+          export ProductVersion=6.4.0
+          service puppetmaster restart
+          ./home/ubuntu/wso2-init.sh ${WUMUsername} ${WUMPassword} wso2ei-640 ${InternalPrepareForTest}
+          sed -i "s/access-key/${AWSAccessKeyId}/g" /etc/puppet/code/environments/production/modules/ei_integrator640/manifests/params.pp
+          sed -i "s/REGION_NAME/${AWS::Region}/g" /etc/puppet/code/environments/production/modules/ei_integrator640/manifests/params.pp
+          sed -i "s/CF_ELB_DNS_NAME/${WSO2EILoadBalancer.DNSName}/g" /etc/puppet/code/environments/production/modules/ei_integrator640/manifests/params.pp
+          sed -i "s/CF_DB_USERNAME/${DBUsername}/g" /etc/puppet/code/environments/production/modules/ei_integrator640/manifests/params.pp
+          sed -i "s/CF_DB_PASSWORD/${DBPassword}/g" /etc/puppet/code/environments/production/modules/ei_integrator640/manifests/params.pp
+          sed -i "s/CF_RDS_URL/${WSO2EIDBInstance.Endpoint.Address}/g" /etc/puppet/code/environments/production/modules/ei_integrator640/manifests/params.pp
+          sed -i "s/BROKER_ELB_DNS_NAME/'localhost'/g" /etc/puppet/code/environments/production/modules/ei_integrator640/manifests/params.pp
+          sed -i "s^secretkey^${AWSAccessKeySecret}^g" /etc/puppet/code/environments/production/modules/ei_integrator640/manifests/params.pp
+          sed -i "s/JDK_TYPE/${JDK}/g" /etc/puppet/code/environments/production/modules/ei_integrator640/manifests/params.pp
+          export DB_HOSTNAME=${WSO2EIDBInstance.Endpoint.Address}
+          export DB_PORT=${WSO2EIDBInstance.Endpoint.Port}
+          export DB_USERNAME=${DBUsername}
+          export DB_PASSWORD=${DBPassword}
+          sed -i "s/JDK_TYPE/${JDK}/g" /etc/puppet/code/environments/production/modules/ei_integrator640/manifests/params.pp
+          sed -i "s/CF_DB_USERNAME/${DBUsername}/g" /usr/local/bin/provision_db_ei.sh
+          sed -i "s/CF_DB_PASSWORD/${DBPassword}/g" /usr/local/bin/provision_db_ei.sh
+          sed -i "s/CF_DB_HOST/${WSO2EIDBInstance.Endpoint.Address}/g" /usr/local/bin/provision_db_ei.sh
+          sed -i "s/CF_DB_PORT/${WSO2EIDBInstance.Endpoint.Port}/g" /usr/local/bin/provision_db_ei.sh
+          bash /usr/local/bin/provision_db_ei.sh
   PuppetMasterSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
@@ -514,111 +426,58 @@ Resources:
       SecurityGroups:
         - !Ref WSO2EISecurityGroup
       UserData: !Base64
-        'Fn::Join':
-          - |+
-
-          - - '#!/bin/bash'
-            - 'export PATH=~/.local/bin:$PATH'
-            - apt-get update
-            - apt-get install -y puppet
-            - apt-get install -y nfs-common
-            - sed -i '/\[main\]/a server=puppet' /etc/puppet/puppet.conf
-            - !Join
-              - ''
-              - - export ProductVersion=
-                - !Ref ProductVersion
-            - !Join
-              - ''
-              - - sed -i "s/Product_Version/
-                - !Ref ProductVersion
-                - /g" /home/ubuntu/logstash-6.5.1/logstash-sample.conf
-            - !Join
-              - ''
-              - - sed -i "s^secret-key^
-                - !Ref AWSAccessKeySecret
-                - ^g" /home/ubuntu/logstash-6.5.1/logstash-sample.conf
-            - !Join
-              - ''
-              - - sed -i "s/access-key/
-                - !Ref AWSAccessKeyId
-                - /g" /home/ubuntu/logstash-6.5.1/logstash-sample.conf
-            - !Join
-              - ''
-              - - sed -i "s^ELASTICSEARCH_ENDPOINT^
-                - !Ref ElasticSearchEndpoint
-                - ^g" /home/ubuntu/logstash-6.5.1/logstash-sample.conf
-            - !Sub "INSTANCEID=$(ec2metadata | grep -m 1 'instance-id:' | awk '{print $2}')"
-            - !Join
-              - ''
-              - - sed -i "s/INSTANCE_ID/
-                - $INSTANCEID
-                - >-
-                  /g"
-                  /home/ubuntu/logstash-6.5.1/logstash-sample.conf
-            - !Join
-              - ''
-              - - sed -i "s/STACK_NAME/
-                - !Ref "AWS::StackName"
-                - >-
-                  /g"
-                  /home/ubuntu/logstash-6.5.1/logstash-sample.conf
-            - !Join
-              - ''
-              - - sed -i "s/REGION_NAME/
-                - !Ref "AWS::Region"
-                - >-
-                  /g"
-                  /home/ubuntu/logstash-6.5.1/logstash-sample.conf
-            - nohup /home/ubuntu/logstash-6.5.1/bin/logstash -f /home/ubuntu/logstash-6.5.1/logstash-sample.conf &
-            - sed -i '/\[main\]/a server=puppet' /etc/puppet/puppet.conf
-            - !Join
-              - ''
-              - - export PuppetmasterIP=
-                - !GetAtt
-                  - PuppetMaster
-                  - PrivateIp
-            - echo "${PuppetmasterIP} puppet puppetmaster" >> /etc/hosts
-            - service puppet restart
-            - mkdir -p /mnt/efs
-            - !Sub "mount -t nfs4 -o nfsvers=4.1 ${WSO2EIEFSFileSystem}.efs.${AWS::Region}.amazonaws.com:/ /mnt/efs"
-            - sleep 180
-            - export FACTER_profile=ei_integrator${ProductVersion//.}
-            - puppet agent -vt
-            - 'if [ ! -d "/mnt/efs/deployment/server" ]; then'
-            - '    mkdir -p /mnt/efs/deployment/server'
-            - '    cp -r /usr/lib/wso2/wso2ei/${ProductVersion}/wso2ei-${ProductVersion}/repository/deployment/server /mnt/efs/deployment'
-            - fi
-            - >-
-              rm -rf
-              /usr/lib/wso2/wso2ei/${ProductVersion}/wso2ei-${ProductVersion}/repository/deployment/server
-            - >-
-              ln -s /mnt/efs/deployment/server
-              /usr/lib/wso2/wso2ei/${ProductVersion}/wso2ei-${ProductVersion}/repository/deployment/server
-            - 'if [ ! -d "/mnt/efs/tenants" ]; then'
-            - '    mkdir -p /mnt/efs/tenants'
-            - '    cp -r /usr/lib/wso2/wso2ei/${ProductVersion}/wso2ei-${ProductVersion}/repository/tenants /mnt/efs'
-            - fi
-            - >-
-              rm -rf
-              /usr/lib/wso2/wso2ei/${ProductVersion}/wso2ei-${ProductVersion}/repository/tenants
-            - >-
-              ln -s /mnt/efs/tenants
-              /usr/lib/wso2/wso2ei/${ProductVersion}/wso2ei-${ProductVersion}/repository/tenants
-            - apt-get install -y python3-pip
-            - pip3 install boto3
-            - echo "${WSO2EIEFSFileSystem}:/ /mnt/efs efs defaults,_netdev 0 0" >> /etc/fstab
-            - !Sub "PRIVATE_IP=$(python3 /usr/local/bin/private_ip_extractor.py ${AWS::Region} ${AWSAccessKeyId} ${AWSAccessKeySecret} WSO2EIInstance1)"
-            - !Join
-              - ''
-              - - sed -i "s/LOCAL-MEMBER-HOST/
-                - $PRIVATE_IP
-                - >-
-                  /g"
-                  /usr/lib/wso2/wso2ei/${ProductVersion}/wso2ei-${ProductVersion}/conf/axis2/axis2.xml
-            - /usr/lib/wso2/wso2ei/${ProductVersion}/wso2ei-${ProductVersion}/bin/integrator.sh start
-            - ${CustomUserData}
-            - echo 'export HISTTIMEFORMAT="%F %T "' >> /etc/profile.d/history.sh
-            - cat /dev/null > ~/.bash_history && history -c
+        'Fn::Sub': |
+          #cloud-boothook
+          #!/bin/bash
+          export PATH=~/.local/bin:$PATH
+          apt-get update
+          apt install -y python-pip
+          apt-get install -y puppet
+          apt-get install -y nfs-common
+          pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
+          sed -i '/\[main\]/a server=puppet' /etc/puppet/puppet.conf
+          export ProductVersion=6.4.0
+          sed -i "s/Product_Version/6.4.0/g" /home/ubuntu/logstash-6.5.1/logstash-sample.conf
+          sed -i "s^secret-key^${AWSAccessKeySecret}^g" /home/ubuntu/logstash-6.5.1/logstash-sample.conf
+          sed -i "s/access-key/${AWSAccessKeyId}/g" /home/ubuntu/logstash-6.5.1/logstash-sample.conf
+          sed -i "s^ELASTICSEARCH_ENDPOINT^${ElasticSearchEndpoint}^g" /home/ubuntu/logstash-6.5.1/logstash-sample.conf
+          export INSTANCEID=$(ec2metadata | grep -m 1 'instance-id:' | awk '{print $2}')
+          sed -i "s/INSTANCE_ID/$INSTANCEID/g" /home/ubuntu/logstash-6.5.1/logstash-sample.conf
+          sed -i "s/STACK_NAME/${AWS::StackName}/g" /home/ubuntu/logstash-6.5.1/logstash-sample.conf
+          sed -i "s/REGION_NAME/${AWS::Region}/g" /home/ubuntu/logstash-6.5.1/logstash-sample.conf
+          nohup /home/ubuntu/logstash-6.5.1/bin/logstash -f /home/ubuntu/logstash-6.5.1/logstash-sample.conf &
+          export PuppetmasterIP=${PuppetMaster.PrivateIp}
+          echo "$PuppetmasterIP puppet puppetmaster" >> /etc/hosts
+          service puppet restart
+          mkdir -p /mnt/efs
+          mount -t nfs4 -o nfsvers=4.1 ${WSO2EIEFSFileSystem}.efs.${AWS::Region}.amazonaws.com:/ /mnt/efs
+          sleep 180
+          export FACTER_profile=ei_integrator640
+          puppet agent -vt
+          if [ ! -d "/mnt/efs/deployment/server" ]; then
+              mkdir -p /mnt/efs/deployment/server
+              cp -r /usr/lib/wso2/wso2ei/6.4.0/wso2ei-6.4.0/repository/deployment/server /mnt/efs/deployment
+          fi
+          rm -rf /usr/lib/wso2/wso2ei/6.4.0/wso2ei-6.4.0/repository/deployment/server
+          ln -s /mnt/efs/deployment/server /usr/lib/wso2/wso2ei/6.4.0/wso2ei-6.4.0/repository/deployment/server
+          if [ ! -d "/mnt/efs/tenants" ]; then
+              mkdir -p /mnt/efs/tenants
+              cp -r /usr/lib/wso2/wso2ei/6.4.0/wso2ei-6.4.0/repository/tenants /mnt/efs
+          fi
+          rm -rf /usr/lib/wso2/wso2ei/6.4.0/wso2ei-6.4.0/repository/tenants
+          ln -s /mnt/efs/tenants /usr/lib/wso2/wso2ei/6.4.0/wso2ei-6.4.0/repository/tenants
+          echo "${WSO2EIEFSFileSystem}:/ /mnt/efs efs defaults,_netdev 0 0" >> /etc/fstab
+          /usr/lib/wso2/wso2ei/6.4.0/wso2ei-6.4.0/bin/integrator.sh start
+          ${CustomUserData}
+          end=$((SECONDS+600))
+          while [ $SECONDS -lt $end ] ; do
+              wget --delete-after --server-response --no-check-certificate "https://localhost:9443/carbon/admin/login.jsp"
+              if [ $? -eq "0" ] ; then
+                /usr/local/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource WSO2EINode1AutoScalingGroup --region ${AWS::Region}
+              fi
+          done
+          echo 'export HISTTIMEFORMAT="%F %T "' >> /etc/profile.d/history.sh
+          cat /dev/null > ~/.bash_history && history -c
     DependsOn:
       - WSO2EISecurityGroup
       - WSO2EILoadBalancer
@@ -643,9 +502,20 @@ Resources:
         - Key: cluster
           Value: ei
           PropagateAtLaunch: 'true'
+    CreationPolicy:
+      ResourceSignal:
+        Count: 1
+        Timeout: PT20M
+    UpdatePolicy:
+      AutoScalingRollingUpdate:
+        MaxBatchSize: '2'
+        MinInstancesInService: '1'
+        PauseTime: PT10M
+        SuspendProcesses:
+          - AlarmNotification
+        WaitOnResourceSignals: true
     DependsOn:
       - WSO2EILoadBalancer
-      - WSO2EINode1LaunchConfiguration
   WSO2EINode2LaunchConfiguration:
     Type: 'AWS::AutoScaling::LaunchConfiguration'
     Properties:
@@ -664,111 +534,58 @@ Resources:
       SecurityGroups:
         - !Ref WSO2EISecurityGroup
       UserData: !Base64
-        'Fn::Join':
-          - |+
-
-          - - '#!/bin/bash'
-            - 'export PATH=~/.local/bin:$PATH'
-            - apt-get update
-            - apt-get install -y puppet
-            - apt-get install -y nfs-common
-            - sed -i '/\[main\]/a server=puppet' /etc/puppet/puppet.conf
-            - !Join
-              - ''
-              - - export ProductVersion=
-                - !Ref ProductVersion
-            - !Join
-              - ''
-              - - sed -i "s/Product_Version/
-                - !Ref ProductVersion
-                - /g" /home/ubuntu/logstash-6.5.1/logstash-sample.conf
-            - !Join
-              - ''
-              - - sed -i "s^secret-key^
-                - !Ref AWSAccessKeySecret
-                - ^g" /home/ubuntu/logstash-6.5.1/logstash-sample.conf
-            - !Join
-              - ''
-              - - sed -i "s/access-key/
-                - !Ref AWSAccessKeyId
-                - /g" /home/ubuntu/logstash-6.5.1/logstash-sample.conf
-            - !Join
-              - ''
-              - - sed -i "s^ELASTICSEARCH_ENDPOINT^
-                - !Ref ElasticSearchEndpoint
-                - ^g" /home/ubuntu/logstash-6.5.1/logstash-sample.conf
-            - !Sub "INSTANCEID=$(ec2metadata | grep -m 1 'instance-id:' | awk '{print $2}')"
-            - !Join
-              - ''
-              - - sed -i "s/INSTANCE_ID/
-                - $INSTANCEID
-                - >-
-                  /g"
-                  /home/ubuntu/logstash-6.5.1/logstash-sample.conf
-            - !Join
-              - ''
-              - - sed -i "s/STACK_NAME/
-                - !Ref "AWS::StackName"
-                - >-
-                  /g"
-                  /home/ubuntu/logstash-6.5.1/logstash-sample.conf
-            - !Join
-              - ''
-              - - sed -i "s/REGION_NAME/
-                - !Ref "AWS::Region"
-                - >-
-                  /g"
-                  /home/ubuntu/logstash-6.5.1/logstash-sample.conf
-            - nohup /home/ubuntu/logstash-6.5.1/bin/logstash -f /home/ubuntu/logstash-6.5.1/logstash-sample.conf &
-            - sed -i '/\[main\]/a server=puppet' /etc/puppet/puppet.conf
-            - !Join
-              - ''
-              - - export PuppetmasterIP=
-                - !GetAtt
-                  - PuppetMaster
-                  - PrivateIp
-            - echo "${PuppetmasterIP} puppet puppetmaster" >> /etc/hosts
-            - service puppet restart
-            - mkdir -p /mnt/efs
-            - !Sub "mount -t nfs4 -o nfsvers=4.1 ${WSO2EIEFSFileSystem}.efs.${AWS::Region}.amazonaws.com:/ /mnt/efs"
-            - sleep 300
-            - export FACTER_profile=ei_integrator${ProductVersion//.}
-            - puppet agent -vt
-            - 'if [ ! -d "/mnt/efs/deployment/server" ]; then'
-            - '    mkdir -p /mnt/efs/deployment/server'
-            - '    cp -r /usr/lib/wso2/wso2ei/${ProductVersion}/wso2ei-${ProductVersion}/repository/deployment/server /mnt/efs/deployment'
-            - fi
-            - >-
-              rm -rf
-              /usr/lib/wso2/wso2ei/${ProductVersion}/wso2ei-${ProductVersion}/repository/deployment/server
-            - >-
-              ln -s /mnt/efs/deployment/server
-              /usr/lib/wso2/wso2ei/${ProductVersion}/wso2ei-${ProductVersion}/repository/deployment/server
-            - 'if [ ! -d "/mnt/efs/tenants" ]; then'
-            - '    mkdir -p /mnt/efs/tenants'
-            - '    cp -r /usr/lib/wso2/wso2ei/${ProductVersion}/wso2ei-${ProductVersion}/repository/tenants /mnt/efs'
-            - fi
-            - >-
-              rm -rf
-              /usr/lib/wso2/wso2ei/${ProductVersion}/wso2ei-${ProductVersion}/repository/tenants
-            - >-
-              ln -s /mnt/efs/tenants
-              /usr/lib/wso2/wso2ei/${ProductVersion}/wso2ei-${ProductVersion}/repository/tenants
-            - apt-get install -y python3-pip
-            - pip3 install boto3
-            - echo "${WSO2EIEFSFileSystem}:/ /mnt/efs efs defaults,_netdev 0 0" >> /etc/fstab
-            - !Sub "PRIVATE_IP=$(python3 /usr/local/bin/private_ip_extractor.py ${AWS::Region} ${AWSAccessKeyId} ${AWSAccessKeySecret} WSO2EIInstance2)"
-            - !Join
-              - ''
-              - - sed -i "s/LOCAL-MEMBER-HOST/
-                - $PRIVATE_IP
-                - >-
-                  /g"
-                  /usr/lib/wso2/wso2ei/${ProductVersion}/wso2ei-${ProductVersion}/conf/axis2/axis2.xml
-            - /usr/lib/wso2/wso2ei/${ProductVersion}/wso2ei-${ProductVersion}/bin/integrator.sh start
-            - ${CustomUserData}
-            - echo 'export HISTTIMEFORMAT="%F %T "' >> /etc/profile.d/history.sh
-            - cat /dev/null > ~/.bash_history && history -c
+        'Fn::Sub': |
+          #cloud-boothook
+          #!/bin/bash
+          export PATH=~/.local/bin:$PATH
+          apt-get update
+          apt install -y python-pip
+          apt-get install -y puppet
+          apt-get install -y nfs-common
+          pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
+          sed -i '/\[main\]/a server=puppet' /etc/puppet/puppet.conf
+          export ProductVersion=6.4.0
+          sed -i "s/Product_Version/6.4.0/g" /home/ubuntu/logstash-6.5.1/logstash-sample.conf
+          sed -i "s^secret-key^${AWSAccessKeySecret}^g" /home/ubuntu/logstash-6.5.1/logstash-sample.conf
+          sed -i "s/access-key/${AWSAccessKeyId}/g" /home/ubuntu/logstash-6.5.1/logstash-sample.conf
+          sed -i "s^ELASTICSEARCH_ENDPOINT^${ElasticSearchEndpoint}^g" /home/ubuntu/logstash-6.5.1/logstash-sample.conf
+          export INSTANCEID=$(ec2metadata | grep -m 1 'instance-id:' | awk '{print $2}')
+          sed -i "s/INSTANCE_ID/$INSTANCEID/g" /home/ubuntu/logstash-6.5.1/logstash-sample.conf
+          sed -i "s/STACK_NAME/${AWS::StackName}/g" /home/ubuntu/logstash-6.5.1/logstash-sample.conf
+          sed -i "s/REGION_NAME/${AWS::Region}/g" /home/ubuntu/logstash-6.5.1/logstash-sample.conf
+          nohup /home/ubuntu/logstash-6.5.1/bin/logstash -f /home/ubuntu/logstash-6.5.1/logstash-sample.conf &
+          export PuppetmasterIP=${PuppetMaster.PrivateIp}
+          echo "$PuppetmasterIP puppet puppetmaster" >> /etc/hosts
+          service puppet restart
+          mkdir -p /mnt/efs
+          mount -t nfs4 -o nfsvers=4.1 ${WSO2EIEFSFileSystem}.efs.${AWS::Region}.amazonaws.com:/ /mnt/efs
+          sleep 300
+          export FACTER_profile=ei_integrator640
+          puppet agent -vt
+          if [ ! -d "/mnt/efs/deployment/server" ]; then
+              mkdir -p /mnt/efs/deployment/server
+              cp -r /usr/lib/wso2/wso2ei/6.4.0/wso2ei-6.4.0/repository/deployment/server /mnt/efs/deployment
+          fi
+          rm -rf /usr/lib/wso2/wso2ei/6.4.0/wso2ei-6.4.0/repository/deployment/server
+          ln -s /mnt/efs/deployment/server /usr/lib/wso2/wso2ei/6.4.0/wso2ei-6.4.0/repository/deployment/server
+          if [ ! -d "/mnt/efs/tenants" ]; then
+              mkdir -p /mnt/efs/tenants
+              cp -r /usr/lib/wso2/wso2ei/6.4.0/wso2ei-6.4.0/repository/tenants /mnt/efs
+          fi
+          rm -rf /usr/lib/wso2/wso2ei/6.4.0/wso2ei-6.4.0/repository/tenants
+          ln -s /mnt/efs/tenants /usr/lib/wso2/wso2ei/6.4.0/wso2ei-6.4.0/repository/tenants
+          echo "${WSO2EIEFSFileSystem}:/ /mnt/efs efs defaults,_netdev 0 0" >> /etc/fstab
+          /usr/lib/wso2/wso2ei/6.4.0/wso2ei-6.4.0/bin/integrator.sh start
+          end=$((SECONDS+600))
+          while [ $SECONDS -lt $end ] ; do
+              wget --delete-after --server-response --no-check-certificate "https://localhost:9443/carbon/admin/login.jsp"
+              if [ $? -eq "0" ] ; then
+                /usr/local/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource WSO2EINode2AutoScalingGroup --region ${AWS::Region}
+              fi
+          done
+          ${CustomUserData}
+          echo 'export HISTTIMEFORMAT="%F %T "' >> /etc/profile.d/history.sh
+          cat /dev/null > ~/.bash_history && history -c
     DependsOn:
       - WSO2EISecurityGroup
       - WSO2EILoadBalancer
@@ -793,9 +610,20 @@ Resources:
         - Key: cluster
           Value: ei
           PropagateAtLaunch: 'true'
+    CreationPolicy:
+      ResourceSignal:
+        Count: 1
+        Timeout: PT20M
+    UpdatePolicy:
+      AutoScalingRollingUpdate:
+        MaxBatchSize: '2'
+        MinInstancesInService: '1'
+        PauseTime: PT10M
+        SuspendProcesses:
+          - AlarmNotification
+        WaitOnResourceSignals: true
     DependsOn:
       - WSO2EILoadBalancer
-      - WSO2EINode2LaunchConfiguration
   WSO2EILoadBalancerSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
@@ -1040,7 +868,6 @@ Parameters:
       - 6.4.0
       - 6.1.1
       - 6.1.0
-      - 6.0.0
 Mappings:
   WSO2PuppetMasterRegionMap:
     ap-southeast-2:

--- a/integrator/integrator-ha.yaml
+++ b/integrator/integrator-ha.yaml
@@ -456,7 +456,7 @@ Resources:
              - ''
              - - sed -i "s/JDK_TYPE/
                - !Ref JDK
-               - /g" /etc/puppet/code/environments/production/modules/ei_integrator${ProductVersion//.}/manifests/params.pp         
+               - /g" /etc/puppet/code/environments/production/modules/ei_integrator${ProductVersion//.}/manifests/params.pp
             - !Join
               - ''
               - - sed -i "s/CF_DB_USERNAME/
@@ -531,12 +531,22 @@ Resources:
               - ''
               - - sed -i "s/Product_Version/
                 - !Ref ProductVersion
-                - /g" /etc/filebeat/filebeat.yml
+                - /g" /home/ubuntu/logstash-6.5.1/logstash-sample.conf
+            - !Join
+              - ''
+              - - sed -i "s^secret-key^
+                - !Ref AWSAccessKeySecret
+                - ^g" /home/ubuntu/logstash-6.5.1/logstash-sample.conf
+            - !Join
+              - ''
+              - - sed -i "s/access-key/
+                - !Ref AWSAccessKeyId
+                - /g" /home/ubuntu/logstash-6.5.1/logstash-sample.conf
             - !Join
               - ''
               - - sed -i "s^ELASTICSEARCH_ENDPOINT^
                 - !Ref ElasticSearchEndpoint
-                - ^g" /etc/filebeat/filebeat.yml
+                - ^g" /home/ubuntu/logstash-6.5.1/logstash-sample.conf
             - !Sub "INSTANCEID=$(ec2metadata | grep -m 1 'instance-id:' | awk '{print $2}')"
             - !Join
               - ''
@@ -544,8 +554,22 @@ Resources:
                 - $INSTANCEID
                 - >-
                   /g"
-                  /etc/filebeat/filebeat.yml
-            - service filebeat start
+                  /home/ubuntu/logstash-6.5.1/logstash-sample.conf
+            - !Join
+              - ''
+              - - sed -i "s/STACK_NAME/
+                - !Ref "AWS::StackName"
+                - >-
+                  /g"
+                  /home/ubuntu/logstash-6.5.1/logstash-sample.conf
+            - !Join
+              - ''
+              - - sed -i "s/REGION_NAME/
+                - !Ref "AWS::Region"
+                - >-
+                  /g"
+                  /home/ubuntu/logstash-6.5.1/logstash-sample.conf
+            - nohup /home/ubuntu/logstash-6.5.1/bin/logstash -f /home/ubuntu/logstash-6.5.1/logstash-sample.conf &
             - sed -i '/\[main\]/a server=puppet' /etc/puppet/puppet.conf
             - !Join
               - ''
@@ -657,12 +681,22 @@ Resources:
               - ''
               - - sed -i "s/Product_Version/
                 - !Ref ProductVersion
-                - /g" /etc/filebeat/filebeat.yml
+                - /g" /home/ubuntu/logstash-6.5.1/logstash-sample.conf
+            - !Join
+              - ''
+              - - sed -i "s^secret-key^
+                - !Ref AWSAccessKeySecret
+                - ^g" /home/ubuntu/logstash-6.5.1/logstash-sample.conf
+            - !Join
+              - ''
+              - - sed -i "s/access-key/
+                - !Ref AWSAccessKeyId
+                - /g" /home/ubuntu/logstash-6.5.1/logstash-sample.conf
             - !Join
               - ''
               - - sed -i "s^ELASTICSEARCH_ENDPOINT^
                 - !Ref ElasticSearchEndpoint
-                - ^g" /etc/filebeat/filebeat.yml
+                - ^g" /home/ubuntu/logstash-6.5.1/logstash-sample.conf
             - !Sub "INSTANCEID=$(ec2metadata | grep -m 1 'instance-id:' | awk '{print $2}')"
             - !Join
               - ''
@@ -670,8 +704,22 @@ Resources:
                 - $INSTANCEID
                 - >-
                   /g"
-                  /etc/filebeat/filebeat.yml
-            - service filebeat start
+                  /home/ubuntu/logstash-6.5.1/logstash-sample.conf
+            - !Join
+              - ''
+              - - sed -i "s/STACK_NAME/
+                - !Ref "AWS::StackName"
+                - >-
+                  /g"
+                  /home/ubuntu/logstash-6.5.1/logstash-sample.conf
+            - !Join
+              - ''
+              - - sed -i "s/REGION_NAME/
+                - !Ref "AWS::Region"
+                - >-
+                  /g"
+                  /home/ubuntu/logstash-6.5.1/logstash-sample.conf
+            - nohup /home/ubuntu/logstash-6.5.1/bin/logstash -f /home/ubuntu/logstash-6.5.1/logstash-sample.conf &
             - sed -i '/\[main\]/a server=puppet' /etc/puppet/puppet.conf
             - !Join
               - ''
@@ -992,7 +1040,7 @@ Parameters:
       - 6.4.0
       - 6.1.1
       - 6.1.0
-      - 6.0.0            
+      - 6.0.0
 Mappings:
   WSO2PuppetMasterRegionMap:
     ap-southeast-2:
@@ -1009,14 +1057,15 @@ Mappings:
       Ubuntu1804: ami-009d089713dae1887
   WSO2EIAMIRegionMap:
     ap-southeast-2:
-      Ubuntu1804: ami-0a017892a7b655b0c
+      Ubuntu1804: ami-01efc89b1e9c78f2f
     eu-west-1:
-      Ubuntu1804: ami-041cdd4bb10bf55a9
+      Ubuntu1804: ami-0ef71f25fc5be6405
     us-east-1:
-      Ubuntu1804: ami-0a000eeff453a3c0e
+      Ubuntu1804: ami-071d17aa9be89c661
     us-east-2:
-      Ubuntu1804: ami-0a2ed85fc335a1ca0
+      Ubuntu1804: ami-073d3f02074c007e5
     us-west-1:
-      Ubuntu1804: ami-0b8d72e3b63b802f9
+      Ubuntu1804: ami-01b4bf9be7d1fb0be
     us-west-2:
-      Ubuntu1804: ami-06623e0f8da384975
+      Ubuntu1804: ami-09362e707f785f606
+

--- a/integrator/integrator-ha.yaml
+++ b/integrator/integrator-ha.yaml
@@ -14,7 +14,7 @@
 
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  WSO2 Enterprise Integrator Clustered deployment
+  WSO2 Enterprise Integrator Clustered deployment with Analytics Configured
 Metadata:
   'AWS::CloudFormation::Interface':
     ParameterGroups:
@@ -282,6 +282,14 @@ Resources:
           ToPort: 22
           CidrIp: 0.0.0.0/0
         - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 9200
+          ToPort: 9200
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
           FromPort: '8280'
           ToPort: '8280'
           SourceSecurityGroupId: !Ref WSO2EILoadBalancerSecurityGroup
@@ -370,7 +378,7 @@ Resources:
               - - export ProductVersion=
                 - !Ref ProductVersion
             - service puppetmaster restart
-            - !Sub "./home/ubuntu/wso2-init.sh ${WUMUsername} ${WUMPassword} wso2ei-${ProductVersion} ${InternalPrepareForTest}"
+            - !Sub "./home/ubuntu/ei-init.sh ${WUMUsername} ${WUMPassword}"
             - !Join
               - ''
               - - sed -i "s/access-key/
@@ -521,6 +529,21 @@ Resources:
                 - !Ref ProductVersion
             - !Join
               - ''
+              - - sed -i "s^ELASTICSEARCH_ENDPOINT^
+                - !Ref ElasticSearchEndpoint
+                - ^g" /etc/filebeat/filebeat.yml
+            - !Sub "INSTANCEID=$(ec2metadata | grep -m 1 'instance-id:' | awk '{print $2}')"
+            - !Join
+              - ''
+              - - sed -i "s/INSTANCE_ID/
+                - $INSTANCEID
+                - >-
+                  /g"
+                  /etc/filebeat/filebeat.yml
+            - service filebeat start
+            - sed -i '/\[main\]/a server=puppet' /etc/puppet/puppet.conf
+            - !Join
+              - ''
               - - export PuppetmasterIP=
                 - !GetAtt
                   - PuppetMaster
@@ -564,6 +587,7 @@ Resources:
                   /g"
                   /usr/lib/wso2/wso2ei/${ProductVersion}/wso2ei-${ProductVersion}/conf/axis2/axis2.xml
             - /usr/lib/wso2/wso2ei/${ProductVersion}/wso2ei-${ProductVersion}/bin/integrator.sh start
+            - mkdir /usr/lib/wso2/wso2ei/${ProductVersion}/wso2ei-${ProductVersion}/mydir
             - ${CustomUserData}
             - echo 'export HISTTIMEFORMAT="%F %T "' >> /etc/profile.d/history.sh
             - cat /dev/null > ~/.bash_history && history -c
@@ -580,8 +604,8 @@ Resources:
       DesiredCapacity: 1
       MinSize: 1
       MaxSize: 1
-      LoadBalancerNames:
-        - !Ref WSO2EILoadBalancer
+      TargetGroupARNs:
+        - !Ref WSO2EIALBTargetGroup
       VPCZoneIdentifier:
         - !Ref WSO2EIPrivateSubnet1
       Tags:
@@ -627,6 +651,21 @@ Resources:
                 - !Ref ProductVersion
             - !Join
               - ''
+              - - sed -i "s^ELASTICSEARCH_ENDPOINT^
+                - !Ref ElasticSearchEndpoint
+                - ^g" /etc/filebeat/filebeat.yml
+            - !Sub "INSTANCEID=$(ec2metadata | grep -m 1 'instance-id:' | awk '{print $2}')"
+            - !Join
+              - ''
+              - - sed -i "s/INSTANCE_ID/
+                - $INSTANCEID
+                - >-
+                  /g"
+                  /etc/filebeat/filebeat.yml
+            - service filebeat start
+            - sed -i '/\[main\]/a server=puppet' /etc/puppet/puppet.conf
+            - !Join
+              - ''
               - - export PuppetmasterIP=
                 - !GetAtt
                   - PuppetMaster
@@ -635,7 +674,7 @@ Resources:
             - service puppet restart
             - mkdir -p /mnt/efs
             - !Sub "mount -t nfs4 -o nfsvers=4.1 ${WSO2EIEFSFileSystem}.efs.${AWS::Region}.amazonaws.com:/ /mnt/efs"
-            - sleep 300
+            - sleep 200
             - export FACTER_profile=ei_integrator${ProductVersion//.}
             - puppet agent -vt
             - 'if [ ! -d "/mnt/efs/deployment/server" ]; then'
@@ -686,10 +725,10 @@ Resources:
       DesiredCapacity: 1
       MinSize: 1
       MaxSize: 1
-      LoadBalancerNames:
-        - !Ref WSO2EILoadBalancer
+      TargetGroupARNs:
+        - !Ref WSO2EIALBTargetGroup
       VPCZoneIdentifier:
-        - !Ref WSO2EIPrivateSubnet1
+        - !Ref WSO2EIPrivateSubnet2
       Tags:
         - Key: Name
           Value: WSO2EIInstance2
@@ -756,75 +795,58 @@ Resources:
           ToPort: '4100'
           CidrIp: 0.0.0.0/0
   WSO2EILoadBalancer:
-    Type: 'AWS::ElasticLoadBalancing::LoadBalancer'
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
-      CrossZone: true
+      Name: EI
+      Scheme: internet-facing
+      Subnets:
+        - !Ref WSO2EIPublicSubnet1
+        - !Ref WSO2EIPublicSubnet2
       SecurityGroups:
         - !Ref WSO2EILoadBalancerSecurityGroup
-      Subnets:
-        - !Ref WSO2EIPublicSubnet2
-        - !Ref WSO2EIPublicSubnet1
-      AppCookieStickinessPolicy:
-        - PolicyName: AppCookieSticky
-          CookieName: JSESSIONID
-      Listeners:
-        - LoadBalancerPort: '80'
-          InstancePort: '9763'
-          Protocol: HTTP
-          InstanceProtocol: HTTP
-          PolicyNames:
-            - AppCookieSticky
-        - LoadBalancerPort: '8280'
-          InstancePort: '8280'
-          Protocol: HTTP
-          InstanceProtocol: HTTP
-          PolicyNames:
-            - AppCookieSticky
-        - LoadBalancerPort: '9443'
-          InstancePort: '9443'
-          Protocol: HTTPS
-          InstanceProtocol: HTTPS
-          PolicyNames:
-            - AppCookieSticky
-          SSLCertificateId: !Join
-            - ''
-            - - 'arn:aws:iam::'
-              - !Ref 'AWS::AccountId'
-              - ':server-certificate'
-              - /
-              - !Ref CertificateName
-        - LoadBalancerPort: '443'
-          InstancePort: '9443'
-          Protocol: HTTPS
-          InstanceProtocol: HTTPS
-          PolicyNames:
-            - AppCookieSticky
-          SSLCertificateId: !Join
-            - ''
-            - - 'arn:aws:iam::'
-              - !Ref 'AWS::AccountId'
-              - ':server-certificate'
-              - /
-              - !Ref CertificateName
-        - LoadBalancerPort: '8243'
-          InstancePort: '8243'
-          Protocol: HTTPS
-          InstanceProtocol: HTTPS
-          PolicyNames:
-            - AppCookieSticky
-          SSLCertificateId: !Join
-            - ''
-            - - 'arn:aws:iam::'
-              - !Ref 'AWS::AccountId'
-              - ':server-certificate'
-              - /
-              - !Ref CertificateName
-      HealthCheck:
-          Target: 'TCP:9763'
-          HealthyThreshold: '3'
-          UnhealthyThreshold: '5'
-          Interval: '10'
-          Timeout: '5'
+  WSO2EIALBTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      HealthCheckIntervalSeconds: 10
+      HealthCheckProtocol: HTTPS
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 4
+      HealthCheckPath: /carbon/admin/login.jsp
+      HealthCheckPort: 9443
+      Matcher:
+        HttpCode: 200
+      Name: ei-carbon-9443
+      Port: 9443
+      Protocol: HTTPS
+      TargetGroupAttributes:
+      - Key: deregistration_delay.timeout_seconds
+        Value: '20'
+      - Key: stickiness.enabled
+        Value: 'true'
+      UnhealthyThresholdCount: 3
+      VpcId:
+        Ref: WSO2EIVPC
+      Tags:
+      - Key: Name
+        Value: ei
+  WSO2EIALBListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref WSO2EIALBTargetGroup
+      Certificates:
+        - CertificateArn: !Join
+          - ''
+          - - 'arn:aws:iam::'
+            - !Ref 'AWS::AccountId'
+            - ':server-certificate'
+            - /
+            - !Ref CertificateName
+      LoadBalancerArn: !Ref WSO2EILoadBalancer
+      Port: 443
+      Protocol: HTTPS
+      SslPolicy: ELBSecurityPolicy-TLS-1-1-2017-01
     DependsOn:
       - WSO2EILoadBalancerSecurityGroup
 Outputs:
@@ -921,6 +943,8 @@ Parameters:
     Type: String
     MinLength: 8
     NoEcho: true
+  ElasticSearchEndpoint:
+    Type: String
   DBAllocationStorage:
     Description: Provide storage size in Gigabytes
     Type: Number
@@ -963,28 +987,27 @@ Parameters:
 Mappings:
   WSO2PuppetMasterRegionMap:
     ap-southeast-2:
-      Ubuntu1804: ami-04736a51961858ebf
+      Ubuntu1804: ami-02148022ba42bf57c
     eu-west-1:
-      Ubuntu1804: ami-0e83183b95e190afc
+      Ubuntu1804: ami-0eb6f72263e3a7343
     us-east-1:
-      Ubuntu1804: ami-0782bf8d5455e6ad0
+      Ubuntu1804: ami-07d85d28eed1ecb20
     us-east-2:
-      Ubuntu1804: ami-001ca894bac471a1b
+      Ubuntu1804: ami-0b3e8926de60d5a28
     us-west-1:
-      Ubuntu1804: ami-0089a017e2b6851a7
+      Ubuntu1804: ami-0be3d1c2a20f79668
     us-west-2:
-      Ubuntu1804: ami-009d089713dae1887
+      Ubuntu1804: ami-0c14a1a779549fba7
   WSO2EIAMIRegionMap:
     ap-southeast-2:
-      Ubuntu1804: ami-07a3bd4944eb120a0
+      Ubuntu1804: ami-022549174964e916b
     eu-west-1:
-      Ubuntu1804: ami-00035f41c82244dab
+      Ubuntu1804: ami-0961894e19ce08142
     us-east-1:
-      Ubuntu1804: ami-0ac019f4fcb7cb7e6
+      Ubuntu1804: ami-0ccb4945e74d10fc5
     us-east-2:
-      Ubuntu1804: ami-0f65671a86f061fcd
+      Ubuntu1804: ami-04b9a444e56fed93d
     us-west-1:
-      Ubuntu1804: ami-063aa838bd7631e0b
+      Ubuntu1804: ami-06c2c5a11123363ed
     us-west-2:
-      Ubuntu1804: ami-0bbe6b35405ecebdb
-
+      Ubuntu1804: ami-0b6a55159dbc3b079

--- a/integrator/integrator-ha.yaml
+++ b/integrator/integrator-ha.yaml
@@ -378,7 +378,7 @@ Resources:
               - - export ProductVersion=
                 - !Ref ProductVersion
             - service puppetmaster restart
-            - !Sub "./home/ubuntu/ei-init.sh ${WUMUsername} ${WUMPassword}"
+            - !Sub "./home/ubuntu/wso2-init.sh ${WUMUsername} ${WUMPassword} wso2ei-${ProductVersion} ${InternalPrepareForTest}"
             - !Join
               - ''
               - - sed -i "s/access-key/


### PR DESCRIPTION
## Purpose
> Change the previous Elastic load balancers to application load balancers
> Add a method to maintain logs in a centralized location. ( ElasticSearch )

## Goals
> Allow users to easily view wso2carbon logs

## Approach
> ElasticSearch endpoint URL is added as a parameter and the users could point to their own elasticsearch endpoint to maintain logs.
