### PR TITLE
Fix wso2-init.sh issue

### DIFF
--- a/integrator/integrator-ha.yaml
+++ b/integrator/integrator-ha.yaml
@@ -376,6 +376,7 @@ Resources:
             - sed -i '/\[main\]/a dns_alt_names=puppetmaster,puppet' /etc/puppet/puppet.conf
             - sed -i '/\[master\]/a autosign=true' /etc/puppet/puppet.conf
             - service puppetmaster restart
+            - cd /home/ubuntu
             - wget -O wso2-init.sh https://wso2-cloudformation-templates.s3.amazonaws.com/wso2-init.sh
             - chmod +x wso2-init.sh
             - !Sub "./home/ubuntu/wso2-init.sh ${WUMUsername} ${WUMPassword} wso2ei-6.4.0 False"


### PR DESCRIPTION
## Purpose
Change the download location of wso2-init.sh to /home/ubuntu/ 

## Goals
Change the download location of wso2-init.sh to /home/ubuntu/ 